### PR TITLE
Add covariances for the convariance of Parser<T, U>

### DIFF
--- a/src/main/kotlin/lambdada/parsec/io/Reader.kt
+++ b/src/main/kotlin/lambdada/parsec/io/Reader.kt
@@ -3,7 +3,7 @@ package lambdada.parsec.io
 import lambdada.parsec.utils.Location
 import java.net.URL
 
-interface Reader<A> {
+interface Reader<out A> {
 
     fun location(): Location
     fun read(): Pair<A, Reader<A>>?

--- a/src/main/kotlin/lambdada/parsec/parser/Response.kt
+++ b/src/main/kotlin/lambdada/parsec/parser/Response.kt
@@ -7,17 +7,17 @@ import lambdada.parsec.utils.Location
 // Response data structure for Parser Combinator
 //
 
-sealed class Response<I, A>(open val consumed: Boolean) {
+sealed class Response<I, out A>(open val consumed: Boolean) {
 
     //
     // Possible Responses
     //
 
-    data class Accept<I, A>(val value: A,
+    data class Accept<I, out A>(val value: A,
                             val input: Reader<I>,
                             override val consumed: Boolean) : Response<I, A>(consumed)
 
-    data class Reject<I, A>(val location: Location,
+    data class Reject<I, out A>(val location: Location,
                             override val consumed: Boolean) : Response<I, A>(consumed)
 
     //


### PR DESCRIPTION
Hello :smiley:

I want to allow below code :point_down:

```kotlin
sealed class Foo {
    data class Bar(val x: Int) : Foo()
    data class Baz(val x: Char) : Foo()
}

val barParser: Parser<Char, Foo.Bar> = /* some */
val bazParser: Parser<Char, Foo.Baz> = /* some */
val fooParser: Parser<Char, Foo> = barParser or bazParser
```

But this doesn't allow, because `Parser<T, U>` is not covariant.

This PR allows it! :+1: